### PR TITLE
fix the way endianness is detected

### DIFF
--- a/vstruct/io/endianness.lua
+++ b/vstruct/io/endianness.lua
@@ -36,7 +36,7 @@ function e.probe()
   -- or not. HACK HACK HACK - this is unlikely to work in anything but the
   -- reference implementation.
   elseif string.dump then
-    bigendian = string.byte(string.dump(function() end, 7)) == 0x00
+    bigendian = string.byte(string.dump(function() end), 7) == 0x00
     
   -- if neither jit nor string.dump is available, we guess wildly that it's
   -- a little-endian system (and emit a warning)


### PR DESCRIPTION
I believe the code used to detect endianness is similar to this thread: http://lua-users.org/lists/lua-l/2008-11/msg00075.html.

However, the current code fails to detect the correct endianness on openWRT system on a MIPS cpu (which is big endian)
