### PR TITLE
Add rockspec file

### DIFF
--- a/vstruct-2.0.0-1.rockspec
+++ b/vstruct-2.0.0-1.rockspec
@@ -1,0 +1,52 @@
+package = "vstruct"
+version = "2.0.0-1"
+source = {
+   url = "git+https://github.com/ToxicFrog/vstruct.git",
+   tag = "v2.0.0"
+}
+description = {
+   summary = "Lua library to manipulate binary data",
+   homepage = "https://github.com/ToxicFrog/vstruct",
+}
+dependencies = {
+  "lua >= 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      ["vstruct.api"] = "api.lua",
+      ["vstruct.ast"] = "ast.lua",
+      ["vstruct.ast.Bitpack"] = "ast/Bitpack.lua",
+      ["vstruct.ast.IO"] = "ast/IO.lua",
+      ["vstruct.ast.List"] = "ast/List.lua",
+      ["vstruct.ast.Name"] = "ast/Name.lua",
+      ["vstruct.ast.Node"] = "ast/Node.lua",
+      ["vstruct.ast.Repeat"] = "ast/Repeat.lua",
+      ["vstruct.ast.Root"] = "ast/Root.lua",
+      ["vstruct.ast.Table"] = "ast/Table.lua",
+      ["vstruct.compat1x"] = "compat1x.lua",
+      ["vstruct.cursor"] = "cursor.lua",
+      ["vstruct"] = "init.lua",
+      ["vstruct.io"] = "io.lua",
+      ["vstruct.io.a"] = "io/a.lua",
+      ["vstruct.io.b"] = "io/b.lua",
+      ["vstruct.io.bigendian"] = "io/bigendian.lua",
+      ["vstruct.io.c"] = "io/c.lua",
+      ["vstruct.io.defaults"] = "io/defaults.lua",
+      ["vstruct.io.endianness"] = "io/endianness.lua",
+      ["vstruct.io.f"] = "io/f.lua",
+      ["vstruct.io.hostendian"] = "io/hostendian.lua",
+      ["vstruct.io.i"] = "io/i.lua",
+      ["vstruct.io.littleendian"] = "io/littleendian.lua",
+      ["vstruct.io.m"] = "io/m.lua",
+      ["vstruct.io.p"] = "io/p.lua",
+      ["vstruct.io.s"] = "io/s.lua",
+      ["vstruct.io.seekb"] = "io/seekb.lua",
+      ["vstruct.io.seekf"] = "io/seekf.lua",
+      ["vstruct.io.seekto"] = "io/seekto.lua",
+      ["vstruct.io.u"] = "io/u.lua",
+      ["vstruct.io.x"] = "io/x.lua",
+      ["vstruct.io.z"] = "io/z.lua",
+      ["vstruct.lexer"] = "lexer.lua",
+   }
+}


### PR DESCRIPTION
This pull request adds a rockspec file to be able to upload this package to LuaRocks.

I am about to write a font parser, where I am planning to use vstruct for binary parsing. I already use LuaRocks for all my Lua modules, so I would like to make this new library available with LuaRocks as well. I don’t want to include vstruct in my repo, and neither do I want to put the burden on the user to install this themselves. 

I can handle the upload to LuaRocks if you like, for this release and all subsequent releases. For now, all you need to do is to accept this pull request, and tag the latest commit after the merge as `v2.0.0`.

If you would like to do the LuaRocks upload yourself,  here is a quick set of instructions after you merge this request and update your repo locally:

1. Tag a release as `v2.0.0` (`git tag v2.0.0` and `git push --tags`)
2. Install LuaRocks
3. Register for an account with LuaRocks server: https://luarocks.org/register
4. Login with account, and generate an API Key at https://luarocks.org/settings/api-keys
5. Upload LuaRocks to server : `luarocks upload --api-key="xxxxx…" vstruct-2.0.0-1.rockspec`