### PR TITLE
Fix version number in rockspec file (2.0.0 -> 2.0.1)

### DIFF
--- a/vstruct-2.0.1-1.rockspec
+++ b/vstruct-2.0.1-1.rockspec
@@ -1,8 +1,8 @@
 package = "vstruct"
-version = "2.0.0-1"
+version = "2.0.1-1"
 source = {
    url = "git+https://github.com/ToxicFrog/vstruct.git",
-   tag = "v2.0.0"
+   tag = "v2.0.1"
 }
 description = {
    summary = "Lua library to manipulate binary data",


### PR DESCRIPTION
The rockspec file contained the wrong version number. This pull request fixes that by updating the version number.

However, in order to do a LuaRocks upload, I will need you to do the following:

* Merge this commit
* Update your local copy
* Re-tag v2.0.1 by deleting the previous tag (`git tag -D v2.0.1`) and then doing `git tag v2.0.1 && git push -f --tags`

Once this is done, I can just use my API key to upload the rockspec to LuaRocks server. After that, anybody doing a `luarocks install vstruct` will be able to pull the sources from your repo on github and install it on their system.